### PR TITLE
Update Readme: Mention docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ git clone https://github.com/perun-network/perun-polkadot-backend
 cd perun-polkadot-backend
 ```
 
-2. Start a local substrate chain by following the instructions in our [polkadot node] repo.
+2. Start a local substrate chain by following the instructions in our [polkadot node] repo, or by using our precompiled docker image:
+```sh
+docker run --rm -p9944:9944 perunnetwork/polkadot-test-node
+```
 
 3. Run all tests:  
 ```sh

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run --rm -p9944:9944 perunnetwork/polkadot-test-node
 
 3. Run all tests:  
 ```sh
-go test -p 1 ./...
+go test -p 1 ./... -v
 ```
 This can take while but should eventually finish successfully. The long testing time results from the block-time of the node, which is set to one second.  
 The `-p 1` flag is important, since the tests otherwise are started in parallel and mess up


### PR DESCRIPTION
To make running the tests easier, we can mention our docker image.

(Also suggests to run tests in verbose to see more output.)