### PR TITLE
Upgrade: go-perun v0.10.5

### DIFF
--- a/client/appchannel_test.go
+++ b/client/appchannel_test.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
@@ -32,8 +31,9 @@ import (
 )
 
 func TestAppChannel(t *testing.T) {
+	rng := pkgtest.Prng(t)
 	s := ptest.NewSetup(t)
-	setups := makeRoleSetups(s, [2]string{"Paul", "Paula"})
+	setups := makeRoleSetups(rng, s, [2]string{"Paul", "Paula"})
 
 	const A, B = 0, 1
 	roles := [2]clienttest.Executer{
@@ -41,7 +41,6 @@ func TestAppChannel(t *testing.T) {
 		clienttest.NewPaula(t, setups[B]),
 	}
 
-	rng := pkgtest.Prng(t)
 	appAddress := test.NewRandomAddress(rng)
 	app := channel.NewMockApp(appAddress)
 	channel.RegisterApp(app)
@@ -57,6 +56,5 @@ func TestAppChannel(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeoutBlocks*s.BlockTime)
 	defer cancel()
-	err := clienttest.ExecuteTwoPartyTest(ctx, roles, execConfig)
-	assert.NoError(t, err)
+	clienttest.ExecuteTwoPartyTest(ctx, t, roles, execConfig)
 }

--- a/client/dispute_test.go
+++ b/client/dispute_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v3/types"
-	"github.com/stretchr/testify/assert"
 	pclient "perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
 	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
 
 	"github.com/perun-network/perun-polkadot-backend/channel"
 	"github.com/perun-network/perun-polkadot-backend/channel/pallet/test"
@@ -33,6 +33,7 @@ import (
 const TestTimeoutBlocks = 100
 
 func TestDisputeMalloryCarol(t *testing.T) {
+	rng := pkgtest.Prng(t)
 	s := test.NewSetup(t)
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeoutBlocks*s.BlockTime)
 	defer cancel()
@@ -47,7 +48,7 @@ func TestDisputeMalloryCarol(t *testing.T) {
 		role [2]clienttest.Executer
 	)
 
-	setup := makeRoleSetups(s, name)
+	setup := makeRoleSetups(rng, s, name)
 	role[A] = clienttest.NewMallory(t, setup[A])
 	role[B] = clienttest.NewCarol(t, setup[B])
 
@@ -74,7 +75,6 @@ func TestDisputeMalloryCarol(t *testing.T) {
 		wallet.AsAddr(s.Bob.Acc.Address()).AccountID():   bobToAlice,
 	}
 	s.AssertBalanceChanges(deltas, epsilon, func() {
-		err := clienttest.ExecuteTwoPartyTest(ctx, role, execConfig)
-		assert.NoError(t, err)
+		clienttest.ExecuteTwoPartyTest(ctx, t, role, execConfig)
 	})
 }

--- a/client/happy_test.go
+++ b/client/happy_test.go
@@ -22,15 +22,16 @@ import (
 	pclient "perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
 	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v3/types"
 	"github.com/perun-network/perun-polkadot-backend/channel"
 	"github.com/perun-network/perun-polkadot-backend/channel/pallet/test"
 	"github.com/perun-network/perun-polkadot-backend/wallet"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHappyAliceBob(t *testing.T) {
+	rng := pkgtest.Prng(t)
 	s := test.NewSetup(t)
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeoutBlocks*s.BlockTime)
 	defer cancel()
@@ -45,7 +46,7 @@ func TestHappyAliceBob(t *testing.T) {
 		role [2]clienttest.Executer
 	)
 
-	setup := makeRoleSetups(s, name)
+	setup := makeRoleSetups(rng, s, name)
 	role[A] = clienttest.NewAlice(t, setup[A])
 	role[B] = clienttest.NewBob(t, setup[B])
 
@@ -72,7 +73,6 @@ func TestHappyAliceBob(t *testing.T) {
 		wallet.AsAddr(s.Bob.Acc.Address()).AccountID():   bobToAlice,
 	}
 	s.AssertBalanceChanges(deltas, epsilon, func() {
-		err := clienttest.ExecuteTwoPartyTest(ctx, role, execConfig)
-		assert.NoError(t, err)
+		clienttest.ExecuteTwoPartyTest(ctx, t, role, execConfig)
 	})
 }

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -15,6 +15,7 @@
 package client_test
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/perun-network/perun-polkadot-backend/channel/pallet/test"
@@ -22,9 +23,10 @@ import (
 	clienttest "perun.network/go-perun/client/test"
 	"perun.network/go-perun/watcher/local"
 	"perun.network/go-perun/wire"
+	netwire "perun.network/go-perun/wire/net/simple"
 )
 
-func makeRoleSetups(s *test.Setup, names [2]string) (setup [2]clienttest.RoleSetup) {
+func makeRoleSetups(rng *rand.Rand, s *test.Setup, names [2]string) (setup [2]clienttest.RoleSetup) {
 	bus := wire.NewLocalBus()
 	for i := 0; i < len(setup); i++ {
 		watcher, err := local.NewWatcher(s.Adjs[i])
@@ -33,7 +35,7 @@ func makeRoleSetups(s *test.Setup, names [2]string) (setup [2]clienttest.RoleSet
 		}
 		setup[i] = clienttest.RoleSetup{
 			Name:              names[i],
-			Identity:          s.Accs[i].Acc,
+			Identity:          netwire.NewRandomAccount(rng),
 			Bus:               bus,
 			Funder:            s.Funders[i],
 			Adjudicator:       s.Adjs[i],

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/vedhavyas/go-subkey v1.0.2
-	perun.network/go-perun v0.9.2
+	perun.network/go-perun v0.10.5
 	polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37
 )
 

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-perun.network/go-perun v0.9.2 h1:wDHh+/KmprbkvjRwNTNY26F8wPbfBmuCYfa49H+VamI=
-perun.network/go-perun v0.9.2/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
+perun.network/go-perun v0.10.5 h1:bIaAoLLh8R+RXdPh+MkCJcbtumsFkNvoVAJwb60JKjg=
+perun.network/go-perun v0.10.5/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
 polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37 h1:iA5GzEa/hHfVlQpimEjPV09NATwHXxSjWNB0VVodtew=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=

--- a/wallet/sr25519/address_test.go
+++ b/wallet/sr25519/address_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	pkgtest "polycry.pt/poly-go/test"
 
 	"github.com/perun-network/perun-polkadot-backend/pkg/substrate"
 	wallet "github.com/perun-network/perun-polkadot-backend/wallet/sr25519"
@@ -40,19 +39,5 @@ func TestAddress_SS58Addr(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, addr.Value, gotAddr)
 		}
-	}
-}
-
-// TestAddress_ZeroCmp tests that the zero address is strictly
-// smaller than all other addresses.
-func TestAddress_ZeroCmp(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	r := test.NewRandomizer()
-	addr := r.NewRandomAddress(rng)
-	zero := test.NewAddressZero()
-
-	for i := 0; i < 1000; i++ {
-		require.False(t, addr.Cmp(zero) < 0)
-		require.False(t, zero.Cmp(addr) > 0)
 	}
 }


### PR DESCRIPTION
This PR upgrades go-perun to version 0.10.5.