### PR TITLE
Adapt to go-perun v0.11.0

### DIFF
--- a/channel/app.go
+++ b/channel/app.go
@@ -1,0 +1,96 @@
+// Copyright 2024 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"math/rand"
+
+	dotwallet "github.com/perun-network/perun-polkadot-backend/wallet/sr25519"
+	dottestwallet "github.com/perun-network/perun-polkadot-backend/wallet/sr25519/test"
+	"perun.network/go-perun/channel"
+)
+
+var _ channel.AppID = new(AppID)
+
+// AppID is an app identifier and
+// OffIdentity is the type of the app identifier (serialized address).
+type AppID struct {
+	OffIdentity
+}
+
+// AppIDKey is the key representation of an app identifier.
+type AppIDKey string
+
+// Equal compares two AppID objects for equality.
+func (a AppID) Equal(b channel.AppID) bool {
+	bTyped, ok := b.(*AppID)
+	if !ok {
+		return false
+	}
+	return a.OffIdentity == bTyped.OffIdentity
+
+}
+
+// Key returns the key representation of this app identifier.
+func (a AppID) Key() channel.AppIDKey {
+	b, err := a.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return channel.AppIDKey(b)
+}
+
+// MarshalBinary marshals the contents of AppID into a byte string.
+func (a AppID) MarshalBinary() ([]byte, error) {
+	data := a.OffIdentity
+	return data[:], nil
+	// return data, nil
+}
+
+// UnmarshalBinary converts a bytestring, representing AppID into the AppID struct.
+func (a *AppID) UnmarshalBinary(data []byte) error {
+	addr := &dotwallet.Address{}
+	err := addr.UnmarshalBinary(data)
+	if err != nil {
+		return err
+	}
+
+	var appIdent [OffIdentityLen]byte
+	copy(appIdent[:], data)
+
+	appaddr := &AppID{appIdent}
+	*a = *appaddr
+	return nil
+}
+
+func NewRandomAppID(rng *rand.Rand) *AppID {
+	addr := dottestwallet.NewRandomAddress(rng)
+
+	// Assuming addr is of type wallet.Address, and we need sr25519.Address
+	// Convert or cast the address to sr25519.Address if possible
+	srAddr, ok := addr.(*dotwallet.Address)
+	if !ok {
+		panic("address is not of type *sr25519.Address")
+	}
+	appIdent, err := srAddr.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	var offIdentity OffIdentity
+	copy(offIdentity[:], appIdent)
+
+	return &AppID{offIdentity}
+}

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PolyCrypt GmbH
+// Copyright 2024 PolyCrypt GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ package channel
 
 import (
 	"fmt"
-	"log"
-
 	eth "github.com/ethereum/go-ethereum/crypto"
+	dotwallet "github.com/perun-network/perun-polkadot-backend/wallet/sr25519"
+	"log"
 	pchannel "perun.network/go-perun/channel"
 	pwallet "perun.network/go-perun/wallet"
 )
@@ -79,4 +79,17 @@ func CalcID(params *pchannel.Params) (id pchannel.ID) {
 		log.Panicf("could not encode parameters: %v", err)
 	}
 	return eth.Keccak256Hash(bytes)
+}
+
+// NewAppID creates a new app identifier
+func (b *backend) NewAppID() pchannel.AppID {
+	addr := &dotwallet.Address{}
+	appIdent, err := addr.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	var offIdentity OffIdentity
+	copy(offIdentity[:], appIdent)
+	return &AppID{offIdentity}
 }

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PolyCrypt GmbH
+// Copyright 2024 PolyCrypt GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,8 +63,6 @@ type (
 	Balance = types.U128
 	// Sig is an off-chain signature.
 	Sig = [SigLen]byte
-	// AppID is the identifier of a channel application.
-	AppID = OffIdentity
 
 	// Params holds the fixed parameters of a channel and uniquely identifies it.
 	Params struct {

--- a/channel/encoding.go
+++ b/channel/encoding.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PolyCrypt GmbH
+// Copyright 2024 PolyCrypt GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,19 +195,24 @@ func NewParams(p *pchannel.Params) (*Params, error) {
 		return nil, err
 	}
 
-	var appID OffIdentity
+	var appDef AppID
 	if !pchannel.IsNoApp(p.App) {
-		appID, err = MakeOffIdent(p.App.Def())
-		if err != nil {
-			return nil, err
+		var ok bool
+		appDefPtr, ok := p.App.Def().(*AppID)
+		if !ok {
+			panic("appDef is not of type *AppID")
 		}
+		appDef = *appDefPtr
+
+	} else {
+		appDef = AppID{OffIdentity: [32]byte{}}
 	}
 
 	return &Params{
 		Nonce:             nonce,
 		Participants:      parts,
 		ChallengeDuration: MakeChallengeDuration(p.ChallengeDuration),
-		App:               appID,
+		App:               appDef,
 	}, err
 }
 

--- a/channel/pallet/adjudicator_sub.go
+++ b/channel/pallet/adjudicator_sub.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PolyCrypt GmbH
+// Copyright 2024 PolyCrypt GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,12 +133,18 @@ func (s *AdjudicatorSub) makePerunEvent(event channel.PerunEvent) (pchannel.Adju
 			return nil, err
 		}
 
-		appPK, err := pkg_sr25519.NewPK(event.App[:])
+		appPK, err := pkg_sr25519.NewPK(event.App.OffIdentity[:])
 		if err != nil {
 			return nil, err
 		}
 		appAddr := sr25519.NewAddressFromPK(appPK)
-		app, err := pchannel.Resolve(appAddr)
+		appIdent, err := appAddr.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		var offIdentity channel.OffIdentity
+		copy(offIdentity[:], appIdent)
+		app, err := pchannel.Resolve(&channel.AppID{OffIdentity: offIdentity})
 		if err != nil {
 			return nil, err
 		}

--- a/client/appchannel_test.go
+++ b/client/appchannel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 - See NOTICE file for copyright holders.
+// Copyright 2024 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,7 +55,14 @@ func TestAppChannel(t *testing.T) {
 
 	appAddress := dotwallet.NewAddressFromPK(pk)
 	require.NoError(t, err)
-	app := channel.NewMockApp(appAddress)
+
+	appIdent, err := appAddress.MarshalBinary()
+	require.NoError(t, err)
+
+	var offIdentity pchannel.OffIdentity
+	copy(offIdentity[:], appIdent)
+
+	app := channel.NewMockApp(&pchannel.AppID{OffIdentity: offIdentity})
 	channel.RegisterApp(app)
 
 	execConfig := &clienttest.ProgressionExecConfig{

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.2
 	github.com/vedhavyas/go-subkey v1.0.2
-	perun.network/go-perun v0.10.6
+	perun.network/go-perun v0.11.0
 	polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37
 )
 
@@ -24,6 +24,7 @@ require (
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa h1:Q75Upo5UN4JbPFURXZ8nLKYUvF85dyFRop/vQ0Rv+64=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -308,7 +310,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-perun.network/go-perun v0.10.6 h1:uj1e33yfCSfE75DK/uwjNp+TwvGG85Qhi6HuYQ9EPrQ=
-perun.network/go-perun v0.10.6/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
+perun.network/go-perun v0.11.0 h1:25aL0MsyXQ2rHziOnMwJMe70K6NTCbopZMwX67qxt/k=
+perun.network/go-perun v0.11.0/go.mod h1:pY/1pJ2OMlCQgEbnfGh9wVfRMJtqN0iAKsiJBLH0/Gc=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37 h1:iA5GzEa/hHfVlQpimEjPV09NATwHXxSjWNB0VVodtew=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=

--- a/wallet/sr25519/test/wallet.go
+++ b/wallet/sr25519/test/wallet.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PolyCrypt GmbH
+// Copyright 2024 PolyCrypt GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,13 @@ func (w *Wallet) NewRandomAccount(rng *rand.Rand) pwallet.Account {
 // other addresses.
 func NewAddressZero() *sr25519.Address {
 	return sr25519.NewAddressFromPK(ZeroPK())
+}
+func NewRandomAddress(rng *rand.Rand) pwallet.Address {
+	pk, err := pkgsr25519.NewPKFromRng(rng)
+	if err != nil {
+		panic(err)
+	}
+	return sr25519.NewAddressFromPK(pk)
 }
 
 // ZeroPK returns a PK that can be used to create a zero address.


### PR DESCRIPTION
This PR updates the code for compatibility with go-perun v0.11.0. In particular, we introduce the new AppID type and update the code accordingly.